### PR TITLE
When referrer is present group as referral

### DIFF
--- a/lib/channel_grouping.rb
+++ b/lib/channel_grouping.rb
@@ -23,6 +23,7 @@ module ChannelGrouping
     return 'Social' if source.social_network?
     return 'Direct' if source.direct? && (medium == 'none' || medium.nil?)
     return 'Direct' if source.host == destination.host
+    return 'Referral' if source.host && (medium == 'none' || medium.nil?)
 
     'Other'
   end

--- a/lib/channel_grouping/destination.rb
+++ b/lib/channel_grouping/destination.rb
@@ -22,6 +22,8 @@ module ChannelGrouping
 
     def uri
       @uri ||= URI(url.to_s)
+    rescue URI::InvalidURIError
+      URI('')
     end
 
     def params

--- a/lib/channel_grouping/source.rb
+++ b/lib/channel_grouping/source.rb
@@ -64,6 +64,8 @@ module ChannelGrouping
 
     def uri
       @uri ||= URI(url.to_s)
+    rescue URI::InvalidURIError
+      URI('')
     end
   end
 end

--- a/lib/channel_grouping/version.rb
+++ b/lib/channel_grouping/version.rb
@@ -1,3 +1,3 @@
 module ChannelGrouping
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/channel_grouping_spec.rb
+++ b/spec/channel_grouping_spec.rb
@@ -167,11 +167,23 @@ describe ChannelGrouping do
       end
     end
 
-    context 'when the medium exactly matches referral' do
-      let(:medium) { 'referral' }
+    describe 'Referral' do
+      context 'when the medium exactly matches referral' do
+        let(:medium) { 'referral' }
 
-      it 'returns Referral' do
-        expect(subject).to eq 'Referral'
+        it 'returns Referral' do
+          expect(subject).to eq 'Referral'
+        end
+      end
+
+      context 'when there is a non-direct url referrer' do
+        let(:source_host) { 'some-referrer-host' }
+        let(:medium) { nil }
+        let(:direct) { false }
+
+        it 'returns Referral' do
+          expect(subject).to eq 'Referral'
+        end
       end
     end
 
@@ -230,7 +242,7 @@ describe ChannelGrouping do
     end
 
     describe 'Other' do
-      context 'when no other rules match' do
+      context 'when there is a medium not matching any other rules' do
         let(:medium) { 'some-medium' }
 
         it 'returns Other' do

--- a/spec/destination_spec.rb
+++ b/spec/destination_spec.rb
@@ -45,6 +45,33 @@ module ChannelGrouping
         end
       end
     end
+
+    describe '#host' do
+      context 'when the url is present' do
+        let(:url) { 'http://some-site.com/some/path' }
+
+        it 'returns the host' do
+          expect(Source.new(url).host).to eq 'some-site.com'
+        end
+      end
+
+      context 'when the url is a blank string' do
+        let(:url) { '' }
+
+        it 'returns nil' do
+          expect(Source.new(url).host).to be nil
+        end
+      end
+
+      context 'when the url is invalid' do
+        let(:url) { 'http|someinvalidurl?a|b' }
+
+        it 'returns nil' do
+          expect(Source.new(url).host).to be nil
+        end
+      end
+    end
+
   end
 end
 

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -28,6 +28,32 @@ module ChannelGrouping
       end
     end
 
+    describe '#host' do
+      context 'when the url is present' do
+        let(:url) { 'http://some-site.com/some/path' }
+
+        it 'returns the host' do
+          expect(Source.new(url).host).to eq 'some-site.com'
+        end
+      end
+
+      context 'when the url is a blank string' do
+        let(:url) { '' }
+
+        it 'returns nil' do
+          expect(Source.new(url).host).to be nil
+        end
+      end
+
+      context 'when the url is invalid' do
+        let(:url) { 'http|someinvalidurl?a|b' }
+
+        it 'returns nil' do
+          expect(Source.new(url).host).to be nil
+        end
+      end
+    end
+
     describe '#search_engine?' do
       before do
         allow(YAML).to receive(:load_file).and_return(


### PR DESCRIPTION
- A request with a non-direct source_url should be grouped as Referral
- Prevents invalid urls from raising `InvalidURIError`s