### PR TITLE
Ignore case when matching mediums

### DIFF
--- a/lib/channel_grouping.rb
+++ b/lib/channel_grouping.rb
@@ -8,14 +8,14 @@ module ChannelGrouping
 
     medium = destination.medium
 
-    return 'Email' if medium == 'email'
-    return 'Affiliates' if medium == 'affiliate'
-    return 'Referral' if medium == 'referral'
-    return 'Organic Search' if medium == 'organic'
-    return 'Paid Search' if medium =~ /^(cpc|ppc|paidsearch)$/
-    return 'Other Advertising' if medium =~ /^(cpv|cpa|cpp)$/
-    return 'Display' if medium =~ /^(display|cpm|banner)$/
-    return 'Social' if medium =~ /^(social|social-network|social-media|sm|social network|social media)$/
+    return 'Email' if medium =~ /^email$/i
+    return 'Affiliates' if medium =~ /^affiliate$/i
+    return 'Referral' if medium =~ /^referral$/i
+    return 'Organic Search' if medium =~ /^organic$/i
+    return 'Paid Search' if medium =~ /^(cpc|ppc|paidsearch)$/i
+    return 'Other Advertising' if medium =~ /^(cpv|cpa|cpp)$/i
+    return 'Display' if medium =~ /^(display|cpm|banner)$/i
+    return 'Social' if medium =~ /^(social|social-network|social-media|sm|social network|social media)$/i
 
     source = Source.new(source_url)
 

--- a/lib/channel_grouping/version.rb
+++ b/lib/channel_grouping/version.rb
@@ -1,3 +1,3 @@
 module ChannelGrouping
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/channel_grouping_spec.rb
+++ b/spec/channel_grouping_spec.rb
@@ -239,6 +239,14 @@ describe ChannelGrouping do
           end
         end
       end
+
+      context 'when the medium is a case insensitive match' do
+        let(:medium) { 'Display' }
+
+        it 'returns Display' do
+          expect(subject).to eq 'Display'
+        end
+      end
     end
 
     describe 'Other' do


### PR DESCRIPTION
Allows utm_medium matching to be case insensitive.

For example: utm_medium=display and utm_medium=Display should both be in the same group ('Display')