### PR TITLE
Relax search engine matching

### DIFF
--- a/lib/channel_grouping/source.rb
+++ b/lib/channel_grouping/source.rb
@@ -14,9 +14,8 @@ module ChannelGrouping
     end
 
     def search_engine?
-      self.class.search_engines.any? do |e| 
-        host_matches?(e['host']) &&
-          contains_query_param?(e['search_query_param_key'])
+      self.class.search_engines.any? do |search_engine_host|
+        host_matches?(search_engine_host)
       end
     end
 
@@ -49,17 +48,8 @@ module ChannelGrouping
 
     private
 
-    def host_matches?(regexp_string)
-      host =~ Regexp.new(regexp_string)
-    end
-
-    def contains_query_param?(key)
-      query_param_keys.include?(key)
-    end
-
-    def query_param_keys
-      return [] if uri.query.nil?
-      @query_param_keys ||= CGI::parse(uri.query).keys
+    def host_matches?(other_host)
+      host =~ Regexp.new(other_host)
     end
 
     def uri

--- a/lib/channel_grouping/version.rb
+++ b/lib/channel_grouping/version.rb
@@ -1,3 +1,3 @@
 module ChannelGrouping
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end

--- a/sources.yml
+++ b/sources.yml
@@ -1,204 +1,81 @@
 social_networks:
-  - 'facebook.com'
-  - 'reddit.com'
-  - 't.co'
-  - 'twitter.com'
-  - 'wordpres.com'
-  - 'disqus.com'
-  - 'linkedin.com'
-  - 'lnkd.in'
+  - 'facebook\.com'
+  - 'reddit\.com'
+  - 't\.co'
+  - 'twitter\.com'
+  - 'wordpres\.com'
+  - 'disqus\.com'
+  - 'linkedin\.com'
+  - 'lnkd\.in'
   - 'blogspot'
-  - 'stumbleupon.com'
-  - 'tumblr.com'
-  - 'getpocket.com'
-  - 'glassdoor.com'
-  - 'meetup.com'
-  - 'pinterest.com'
-  - 'plus.url.google.com'
-  - 'youtube.com'
-  - 'yammer.com'
-  - 'plus.google.com'
-  - 'touch.www'
-  - 'diigo.com'
-  - 'news.ycombinator.com'
-  - 'paper.li'
-  - 'digg.com'
-  - 'bigtent.com'
-  - 'blogger.com'
+  - 'stumbleupon\.com'
+  - 'tumblr\.com'
+  - 'getpocket\.com'
+  - 'glassdoor\.com'
+  - 'meetup\.com'
+  - 'pinterest\.com'
+  - 'plus\.url\.google\.com'
+  - 'youtube\.com'
+  - 'yammer\.com'
+  - 'plus\.google\.com'
+  - 'touch\.www'
+  - 'diigo\.com'
+  - 'news\.ycombinator\.com'
+  - 'paper\.li'
+  - 'digg\.com'
+  - 'bigtent\.com'
+  - 'blogger\.com'
   - 'googleplus'
-  - 'groups.google.com'
-  - 'hootsuite.com'
-  - 'instagram.com'
-  - 'instapaper.com'
-  - 'netvibes.com'
-  - 'ow.ly'
-  - 'pinboard.in'
-  - 'quora.com'
-  - 'scoop.it'
-  - 'slashdot.org'
-  - 'tinyurl.com'
+  - 'groups\.google\.com'
+  - 'hootsuite\.com'
+  - 'instagram\.com'
+  - 'instapaper\.com'
+  - 'netvibes\.com'
+  - 'ow\.ly'
+  - 'pinboard\.in'
+  - 'quora\.com'
+  - 'scoop\.it'
+  - 'slashdot\.org'
+  - 'tinyurl\.com'
   - 'twitter'
-  - 'uk.pinterest.com'
-  - 'wikihow.com'
+  - 'uk\.pinterest\.com'
+  - 'wikihow\.com'
 search_engines:
-  -
-   name: Daum
-   host: 'daum\.net'
-   search_query_param_key: 'q'
-  -
-   name: Eniro
-   host: 'eniro\.se'
-   search_query_param_key: 'search_word'
-  -
-   name: Naver
-   host: 'naver\.com'
-   search_query_param_key: 'query'
-  -
-   name: Google
-   host: 'google\.co?'
-   search_query_param_key: 'q'
-  -
-   name: Yahoo
-   host: 'yahoo\.com'
-   search_query_param_key: 'p'
-  -
-   name: MSN
-   host: 'msn\.com'
-   search_query_param_key: 'q'
-  -
-   name: Bing
-   host: 'bing\.com'
-   search_query_param_key: 'q'
-  -
-   name: AOL
-   host: 'aol\.com'
-   search_query_param_key: 'query'
-  -
-   name: AOL Encrypted
-   host: 'aol\.com'
-   search_query_param_key: 'encquery'
-  -
-   name: Lycos
-   host: 'lycos\.com'
-   search_query_param_key: 'query'
-  -
-   name: Ask
-   host: 'ask\.com'
-   search_query_param_key: 'q'
-  -
-   name: Altavista
-   host: 'altavista\.com'
-   search_query_param_key: 'q'
-  -
-   name: Netscape
-   host: 'search\.netscape\.com'
-   search_query_param_key: 'query'
-  -
-   name: CNN
-   host: 'cnn.com\/SEARCH'
-   search_query_param_key: 'query'
-  -
-   name: About
-   host: 'about\.com'
-   search_query_param_key: 'terms'
-  -
-   name: Mamma
-   host: 'mamma\.com'
-   search_query_param_key: 'query'
-  -
-   name: Alltheweb
-   host: 'alltheweb\.com'
-   search_query_param_key: 'q'
-  -
-   name: Voila
-   host: 'voila\.fr'
-   search_query_param_key: 'rdata'
-  -
-   name: Virgilio
-   host: 'search\.virgilio\.it'
-   search_query_param_key: 'qs'
-  -
-   name: Live
-   host: 'bing\.com'
-   search_query_param_key: 'q'
-  -
-   name: Baidu
-   host: 'baidu\.com'
-   search_query_param_key: 'wd'
-  -
-   name: Alice
-   host: 'alice\.com'
-   search_query_param_key: 'qs'
-  -
-   name: Yandex
-   host: 'yandex\.com'
-   search_query_param_key: 'text'
-  -
-   name: Najdi
-   host: 'najdi\.org\.mk'
-   search_query_param_key: 'q'
-  -
-   name: AOL
-   host: 'aol\.com'
-   search_query_param_key: 'q'
-  -
-   name: Mama
-   host: 'mamma\.com'
-   search_query_param_key: 'query'
-  -
-   name: Seznam
-   host: 'seznam\.cz'
-   search_query_param_key: 'q'
-  -
-   name: Search
-   host: 'search\.com'
-   search_query_param_key: 'q'
-  -
-   name: Wirtulana Polska
-   host: 'wp\.pl'
-   search_query_param_key: 'szukaj'
-  -
-   name: O*NET
-   host: 'online\.onetcenter\.org'
-   search_query_param_key: 'qt'
-  -
-   name: Szukacz
-   host: 'szukacz\.pl'
-   search_query_param_key: 'q'
-  -
-   name: Yam
-   host: 'yam\.com'
-   search_query_param_key: 'k'
-  -
-   name: PCHome
-   host: 'pchome\.com'
-   search_query_param_key: 'q'
-  -
-   name: Kvasir
-   host: 'kvasir\.no'
-   search_query_param_key: 'q'
-  -
-   name: Sesam
-   host: 'sesam\.no'
-   search_query_param_key: 'q'
-  -
-   name: Ozu
-   host: 'ozu\.es'
-   search_query_param_key: 'q'
-  -
-   name: Terra
-   host: 'terra\.com'
-   search_query_param_key: 'query'
-  -
-   name: Mynet
-   host: 'mynet\.com'
-   search_query_param_key: 'q'
-  -
-   name: Ekolay
-   host: 'ekolay\.net'
-   search_query_param_key: 'q'
-  -
-   name: Rambler
-   host: 'rambler\.ru'
-   search_query_param_key: 'words'
+  - 'daum\.net'
+  - 'eniro\.se'
+  - 'naver\.com'
+  - 'google\.'
+  - 'yahoo\.com'
+  - 'msn\.com'
+  - 'bing\.'
+  - 'aol\.com'
+  - 'lycos\.com'
+  - 'ask\.com'
+  - 'altavista\.com'
+  - 'search\.netscape\.com'
+  - 'about\.com'
+  - 'mamma\.com'
+  - 'alltheweb\.com'
+  - 'voila\.fr'
+  - 'search\.virgilio\.it'
+  - 'baidu\.com'
+  - 'alice\.com'
+  - 'yandex\.com'
+  - 'najdi\.org\.mk'
+  - 'aol\.com'
+  - 'mamma\.com'
+  - 'seznam\.cz'
+  - 'search\.com'
+  - 'wp\.pl'
+  - 'online\.onetcenter\.org'
+  - 'szukacz\.pl'
+  - 'yam\.com'
+  - 'pchome\.com'
+  - 'kvasir\.no'
+  - 'sesam\.no'
+  - 'ozu\.es'
+  - 'terra\.com'
+  - 'mynet\.com'
+  - 'ekolay\.net'
+  - 'rambler\.ru'
 

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -57,7 +57,7 @@ module ChannelGrouping
     describe '#search_engine?' do
       before do
         allow(YAML).to receive(:load_file).and_return(
-          'search_engines' => [{ 'host' => /search-engine.com/, 'search_query_param_key' => 'q' }]
+          'search_engines' => ['search-engine\.com']
         )
       end
 
@@ -72,26 +72,10 @@ module ChannelGrouping
             expect(Source.new(url).search_engine?).to be true
           end
         end
-
-        context 'and the query string does not contain the search query parameter' do
-          let(:query_string) { 'foo=bar' }
-
-          it 'returns false' do
-            expect(Source.new(url).search_engine?).to be false
-          end
-        end
-
-        context 'and the query string is nil' do
-          let(:query_string) { nil }
-
-          it 'returns false' do
-            expect(Source.new(url).search_engine?).to be false
-          end
-        end
       end
 
       context 'when the source host does not match any search engine hosts' do
-        let(:url) { 'http://www.not-a-search-engine.com' }
+        let(:url) { 'http://www.not-a-search.com' }
 
         it 'returns false' do
           expect(Source.new(url).search_engine?).to be false
@@ -110,7 +94,7 @@ module ChannelGrouping
     describe '#social_network?' do
       before do
         allow(YAML).to receive(:load_file).and_return(
-          'social_networks' => [/facebook.com/, /twitter.com/]
+          'social_networks' => ['facebook\.com', 'twitter\.com']
         )
       end
 


### PR DESCRIPTION
Many search engines no longer pass their search query param in the http referrer.
For example, Google's instant search now puts the query param in the #anchor, which
does not get passed into the HTTP_REFERER

Now the Source will match as a search_engine when the host matches our known list.
This may lead to some false positives, for example yahoo.com news articles may get
listed as search